### PR TITLE
feat: disable dark reader automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="darkreader-lock">
     <title>StarlightSky</title>
     <link rel="stylesheet" href="/assets/style/style.css">
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>


### PR DESCRIPTION
Just disables Dark reader extension, so that the website is viewed as intended. (Didn't test it, no clue if it works :kekw:)